### PR TITLE
Add dev orchestrator to run API and Vite together

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "node scripts/dev.mjs",
+    "client": "vite",
     "server": "tsx watch server/index.ts",
     "server:start": "tsx server/index.ts",
     "build": "tsc -b && tsc -p tsconfig.server.json",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,81 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const services = [];
+let shuttingDown = false;
+
+const log = (message) => {
+  console.log(`[dev] ${message}`);
+};
+
+const startService = (name, script) => {
+  log(`Démarrage de ${name}...`);
+  const child = spawn(npmCommand, ['run', script], {
+    stdio: 'inherit',
+    env: process.env,
+    shell: false
+  });
+
+  services.push({ name, child });
+
+  child.on('error', (error) => {
+    console.error(`[dev] Impossible de lancer ${name}:`, error);
+    void shutdown(1);
+  });
+
+  child.on('exit', (code, signal) => {
+    if (shuttingDown) {
+      return;
+    }
+
+    if (signal) {
+      console.error(`[dev] ${name} s'est arrêté (signal ${signal}).`);
+      void shutdown(1);
+      return;
+    }
+
+    if (typeof code === 'number' && code === 0) {
+      log(`${name} s'est arrêté.`);
+      void shutdown(0);
+    } else {
+      console.error(`[dev] ${name} s'est terminé avec le code ${code ?? 'inconnu'}.`);
+      void shutdown(typeof code === 'number' ? code : 1);
+    }
+  });
+};
+
+const shutdown = async (exitCode = 0) => {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+
+  for (const { name, child } of services) {
+    if (child.exitCode === null && child.signalCode === null) {
+      log(`Arrêt de ${name}...`);
+      child.kill('SIGINT');
+    }
+  }
+
+  for (const { child } of services) {
+    if (child.exitCode === null && child.signalCode === null) {
+      await once(child, 'exit');
+    }
+  }
+
+  process.exit(exitCode);
+};
+
+process.on('SIGINT', () => {
+  log('Signal SIGINT reçu. Arrêt en cours...');
+  void shutdown(0);
+});
+
+process.on('SIGTERM', () => {
+  log('Signal SIGTERM reçu. Arrêt en cours...');
+  void shutdown(0);
+});
+
+startService('API EasyChef', 'server');
+startService('serveur Vite', 'client');


### PR DESCRIPTION
## Summary
- add a Node-based development orchestrator that starts the API and Vite dev server side by side
- wire `npm run dev` to the orchestrator and expose a `client` script for running Vite directly

## Testing
- npm run build *(fails: missing local type packages because dependencies are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c85b2c3ef883278e1836e5a44404a4